### PR TITLE
fix: update S3 deployment destination directory to 'verti-utils'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,5 +22,5 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_DOWNLOADS }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DOWNLOADS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DOWNLOADS_AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: 'artifact'      # optional: defaults to entire repository
-          DEST_DIR: utils/pirate-parrot/latest
+          SOURCE_DIR: "artifact" # optional: defaults to entire repository
+          DEST_DIR: verti-utils


### PR DESCRIPTION
### Changes

The previous workflow was uploading to `s3://downloads.themeisle.com/utils/pirate-parrot/latest/pirate-parrot.zip` instead of `s3://verti-utils/pirate-parrot.zip`. The download link used by the bot is: https://verti-utils.s3.amazonaws.com/pirate-parrot.zip